### PR TITLE
refactor: 공통적으로 사용하는 공통 설정 application.yml로 위임

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,64 +13,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
-  mvc:
-    static-path-pattern: /static/**
 
-  data:
-    redis:
-      client-name: ${secret.redis.client-name}
-      host: ${secret.redis.host}
-      port: ${secret.redis.port}
-      password: ${secret.redis.password}
-
-
-jwt:
-  issuer: ${secret.jwt.issuer}
-  access-secret: ${secret.jwt.access-secret}
-  access-expiration-millis: ${secret.jwt.access-expiration-ms}
-  refresh-secret: ${secret.jwt.refresh-secret}
-  refresh-expiration-millis: ${secret.jwt.refresh-expiration-ms}
-
-oidc:
-  response-millis: ${secret.oidc.response-millis}
-  apple:
-    api:
-      url: ${secret.oidc.apple.url}
-      clientId: ${secret.oidc.apple.client-id}
-  kakao:
-    api:
-      url: ${secret.oidc.kakao.url}
-      clientId: ${secret.oidc.kakao.client-id}
 logging:
-  level:
-    root: info
-  pattern:
-    file: "[%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}][%-5level][%logger.%method:line%line] - %msg%n"
   file:
     name: ${secret.logging.file.name}
-  logback:
-    rollingpolicy:
-      file-name-pattern: ${secret.logging.file.pattern}
-      max-history: 30
-
-management:
-  server:
-    port: ${secret.management.port}
-
-  endpoints:
-    web:
-      exposure:
-        include: prometheus, health
-      base-path: ${secret.management.path}
-    jmx:
-      exposure:
-        exclude: "*"
-    access:
-      default: none
-
-  endpoint:
-    prometheus:
-      access: unrestricted
-    health:
-      show-components: never
-      access: unrestricted

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -44,7 +44,3 @@ oidc:
     api:
       url: https://kauth.kakao.com
       clientId: test-client-id
-
-user:
-  default:
-    profile: test-profile

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,61 @@
 spring:
   profiles:
     active: local
+  data:
+    redis:
+      client-name: ${secret.redis.client-name}
+      host: ${secret.redis.host}
+      port: ${secret.redis.port}
+      password: ${secret.redis.password}
+  mvc:
+    static-path-pattern: /static/**
+
+jwt:
+  issuer: ${secret.jwt.issuer}
+  access-secret: ${secret.jwt.access-secret}
+  access-expiration-millis: ${secret.jwt.access-expiration-ms}
+  refresh-secret: ${secret.jwt.refresh-secret}
+  refresh-expiration-millis: ${secret.jwt.refresh-expiration-ms}
+
+oidc:
+  response-millis: ${secret.oidc.response-millis}
+  apple:
+    api:
+      url: ${secret.oidc.apple.url}
+      clientId: ${secret.oidc.apple.client-id}
+  kakao:
+    api:
+      url: ${secret.oidc.kakao.url}
+      clientId: ${secret.oidc.kakao.client-id}
+
+logging:
+  level:
+    root: info
+  pattern:
+    file: "[%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}][%-5level][%logger.%method:line%line] - %msg%n"
+  logback:
+    rollingpolicy:
+      file-name-pattern: ${secret.logging.file.pattern}
+      max-history: 30
+
+management:
+  server:
+    port: ${secret.management.port}
+
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health
+      base-path: ${secret.management.path}
+    jmx:
+      exposure:
+        exclude: "*"
+    access:
+      default: none
+
+  endpoint:
+    prometheus:
+      access: unrestricted
+    health:
+      show-components: never
+      access: unrestricted


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 123

## 📄 추가 작업 내용
-


## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [ ] 모든 commit이 push 되었나요?
- [ ] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?


## 💬 기타 참고 사항
개발, 운영, 테스트, 로컬 등에서 공통적으로 설정 파일은 동일하고 secret값만 다른 경우에도 매번 환경 파일에 적어주는 것이 불편하게 느껴졌습니다. 어차피 secret을 통해 주입받는다면 굳이 각 환경마다 설정을 적어줄 필요가 있을까 싶어서 기본 설정 파일인 application.yml에 두도록 변경했습니다. 이제 환경에 따라서 다르게 설정해야하는 부분만 각 환경 설정 파일에 추가해주면 됩니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 및 테스트 환경의 설정 파일이 간소화되었습니다.
  * 운영 환경 설정 파일에 Redis, JWT, OIDC, 로깅, 관리 서버 등 다양한 구성 옵션이 추가되었습니다.  
  * 모든 민감 정보는 외부 시크릿에서 주입되도록 개선되었습니다.  
  * 기존 설정 중 불필요한 항목이 제거되어 관리가 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->