### PR TITLE
refactor: RunningRecord가 User를 가지도록 변경

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/record/api/response/RunningPointResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/api/response/RunningPointResponse.kt
@@ -23,7 +23,7 @@ data class RunningPointResponse(
 ) {
     constructor(runningPoint: RunningPoint) : this(
         pointId = runningPoint.id,
-        userId = runningPoint.runningRecord.userId,
+        userId = runningPoint.runningRecord.user.id,
         recordId = runningPoint.runningRecord.id,
         orderNo = runningPoint.orderNo,
         lat = runningPoint.lat,

--- a/src/main/kotlin/com/yapp/yapp/record/api/response/RunningPointXmlResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/api/response/RunningPointXmlResponse.kt
@@ -41,7 +41,7 @@ data class RunningPointXmlResponse(
 ) {
     constructor(runningPoint: RunningPoint) : this(
         pointId = runningPoint.id,
-        userId = runningPoint.runningRecord.userId,
+        userId = runningPoint.runningRecord.user.id,
         recordId = runningPoint.runningRecord.id,
         orderNo = runningPoint.orderNo,
         lat = runningPoint.lat,

--- a/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordResponse.kt
@@ -18,7 +18,7 @@ data class RunningRecordResponse(
 ) {
     constructor(runningRecord: RunningRecord, runningPoints: List<RunningPoint>) : this(
         recordId = runningRecord.id,
-        userId = runningRecord.userId,
+        userId = runningRecord.user.id,
         runningPoints = runningPoints.map { RunningPointResponse(it) },
         segments = SegmentListResponse.of(runningPoints).segmentList,
         totalDistance = runningRecord.totalDistance,

--- a/src/main/kotlin/com/yapp/yapp/record/domain/RunningRecordService.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/RunningRecordService.kt
@@ -4,6 +4,7 @@ import com.yapp.yapp.record.api.response.RunningRecordListResponse
 import com.yapp.yapp.record.api.response.RunningRecordResponse
 import com.yapp.yapp.record.domain.point.RunningPointManger
 import com.yapp.yapp.record.domain.record.RunningRecordManager
+import com.yapp.yapp.user.domain.UserManager
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime
@@ -12,12 +13,14 @@ import java.time.OffsetDateTime
 class RunningRecordService(
     private val recordManager: RunningRecordManager,
     private val pointManager: RunningPointManger,
+    private val userManager: UserManager,
 ) {
     fun getRecord(
         userId: Long,
         recordId: Long,
     ): RunningRecordResponse {
-        val runningRecord = recordManager.getRunningRecord(id = recordId, userId = userId)
+        val user = userManager.getActiveUser(userId)
+        val runningRecord = recordManager.getRunningRecord(id = recordId, user = user)
         val runningPoints = pointManager.getRunningPoints(runningRecord)
         return RunningRecordResponse(runningRecord, runningPoints)
     }
@@ -28,14 +31,15 @@ class RunningRecordService(
         targetDate: OffsetDateTime,
         pageable: Pageable,
     ): RunningRecordListResponse {
+        val user = userManager.getActiveUser(userId)
         val searchType = RecordsSearchType.getBy(type)
         val runningRecordResponse =
             recordManager.getRunningRecords(
-                userId = userId,
+                user = user,
                 searchType = searchType,
                 targetDate = targetDate,
                 pageable = pageable,
             ).map { RunningRecordResponse(it, pointManager.getRunningPoints(it)) }
-        return RunningRecordListResponse(userId = userId, records = runningRecordResponse)
+        return RunningRecordListResponse(userId = user.id, records = runningRecordResponse)
     }
 }

--- a/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecord.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecord.kt
@@ -6,14 +6,18 @@ import com.yapp.yapp.record.domain.RecordStatus
 import com.yapp.yapp.record.domain.RunningMetricsCalculator
 import com.yapp.yapp.record.domain.converter.PaceConverter
 import com.yapp.yapp.record.domain.point.RunningPoint
+import com.yapp.yapp.user.domain.User
 import jakarta.persistence.Column
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import java.time.OffsetDateTime
 
@@ -23,8 +27,9 @@ class RunningRecord(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L,
-    @Column(nullable = false) // TODO user로 바꾸기
-    val userId: Long = 0L,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
     @Column(nullable = false)
     var totalDistance: Double = 0.0,
     @Column(nullable = false)
@@ -83,5 +88,9 @@ class RunningRecord(
         totalCalories?.let { this.totalCalories = it }
         averageSpeed?.let { this.averageSpeed = it }
         averagePace?.let { this.averagePace = it }
+    }
+
+    fun isOwnedBy(user: User): Boolean {
+        return this.user.id == user.id
     }
 }

--- a/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecordDao.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecordDao.kt
@@ -23,15 +23,15 @@ class RunningRecordDao(
     }
 
     fun getRunningRecordList(
-        userId: Long,
+        user: User,
         targetDate: OffsetDateTime,
         type: RecordsSearchType,
         pageable: Pageable? = null,
     ): List<RunningRecord> {
         val startDate = type.getStartDate(targetDate)
         val endDate = type.getEndDate(targetDate)
-        return runningRecordRepository.findByUserIdAndStartAtBetweenOrderByStartAtDesc(
-            userId,
+        return runningRecordRepository.findByUserAndStartAtBetweenOrderByStartAtDesc(
+            user,
             startDate,
             endDate,
             pageable,
@@ -39,13 +39,13 @@ class RunningRecordDao(
     }
 
     fun findRecentRunningRecord(user: User): RunningRecord? {
-        return runningRecordRepository.findFirstByUserIdOrderByStartAtDesc(user.id)
+        return runningRecordRepository.findFirstByUserOrderByStartAtDesc(user)
     }
 
     fun getThisWeekRunningCount(user: User): Int {
         val targetDate = TimeProvider.now()
         val startDate = RecordsSearchType.WEEKLY.getStartDate(targetDate)
         val endDate = RecordsSearchType.WEEKLY.getEndDate(targetDate)
-        return runningRecordRepository.countByUserIdAndStartAtBetween(userId = user.id, startDate = startDate, endDate = endDate)
+        return runningRecordRepository.countByUserAndStartAtBetween(user = user, startDate = startDate, endDate = endDate)
     }
 }

--- a/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecordManager.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecordManager.kt
@@ -19,23 +19,23 @@ class RunningRecordManager(
 ) {
     fun getRunningRecord(
         id: Long,
-        userId: Long,
+        user: User,
     ): RunningRecord {
         val runningRecord = runningRecordDao.getById(id)
-        if (runningRecord.userId != userId) {
+        if (!runningRecord.isOwnedBy(user)) {
             throw CustomException(ErrorCode.RECORD_NO_MATCHED)
         }
         return runningRecord
     }
 
     fun getRunningRecords(
-        userId: Long,
+        user: User,
         searchType: RecordsSearchType,
         targetDate: OffsetDateTime,
         pageable: Pageable,
     ): List<RunningRecord> {
         return runningRecordDao.getRunningRecordList(
-            userId = userId,
+            user = user,
             targetDate = targetDate,
             type = searchType,
             pageable = pageable,
@@ -51,8 +51,8 @@ class RunningRecordManager(
         searchType: RecordsSearchType,
         targetDate: OffsetDateTime,
     ): RunningRecord {
-        val runningRecordList = runningRecordDao.getRunningRecordList(userId = user.id, targetDate = targetDate, type = searchType)
-        val totalRunningRecord = RunningRecord(userId = user.id, recordStatus = RecordStatus.DONE)
+        val runningRecordList = runningRecordDao.getRunningRecordList(user = user, targetDate = targetDate, type = searchType)
+        val totalRunningRecord = RunningRecord(user = user, recordStatus = RecordStatus.DONE)
         if (runningRecordList.isEmpty()) {
             return totalRunningRecord
         }
@@ -71,29 +71,29 @@ class RunningRecordManager(
     }
 
     fun start(
-        userId: Long,
+        user: User,
         startAt: OffsetDateTime,
     ): RunningRecord {
-        val runningRecord = RunningRecord(userId = userId, startAt = startAt)
+        val runningRecord = RunningRecord(user = user, startAt = startAt)
         runningRecord.start()
         return runningRecordDao.save(runningRecord)
     }
 
     fun stop(
         id: Long,
-        userId: Long,
+        user: User,
     ): RunningRecord {
-        val runningRecord = getRunningRecord(id, userId)
+        val runningRecord = getRunningRecord(id, user)
         runningRecord.pause()
         return runningRecord
     }
 
     fun finish(
         id: Long,
-        userId: Long,
+        user: User,
         runningPoints: List<RunningPoint>,
     ): RunningRecord {
-        val record = getRunningRecord(id, userId)
+        val record = getRunningRecord(id, user)
         record.finish()
         record.updateInfoByRunningPoints(runningPoints)
         return record

--- a/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecordRepository.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecordRepository.kt
@@ -1,21 +1,22 @@
 package com.yapp.yapp.record.domain.record
 
+import com.yapp.yapp.user.domain.User
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.CrudRepository
 import java.time.OffsetDateTime
 
 interface RunningRecordRepository : CrudRepository<RunningRecord, Long> {
-    fun findByUserIdAndStartAtBetweenOrderByStartAtDesc(
-        userId: Long,
+    fun findByUserAndStartAtBetweenOrderByStartAtDesc(
+        user: User,
         startDate: OffsetDateTime,
         endDate: OffsetDateTime,
         pageable: Pageable?,
     ): List<RunningRecord>
 
-    fun findFirstByUserIdOrderByStartAtDesc(userId: Long): RunningRecord?
+    fun findFirstByUserOrderByStartAtDesc(user: User): RunningRecord?
 
-    fun countByUserIdAndStartAtBetween(
-        userId: Long,
+    fun countByUserAndStartAtBetween(
+        user: User,
         startDate: OffsetDateTime,
         endDate: OffsetDateTime,
     ): Int

--- a/src/test/kotlin/com/yapp/yapp/document/home/HomeDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/home/HomeDocumentTest.kt
@@ -56,8 +56,8 @@ class HomeDocumentTest : BaseDocumentTest() {
         val user = userFixture.create()
         userGoalFixture.create(user) // 유저 목표 데이터
         val targetDate = TimeProvider.now().with(DayOfWeek.SUNDAY)
-        runningFixture.createRunningRecord(user.id, startAt = targetDate.with(DayOfWeek.MONDAY))
-        runningFixture.createRunningRecord(user.id, startAt = targetDate.with(DayOfWeek.THURSDAY))
+        runningFixture.createRunningRecord(user, startAt = targetDate.with(DayOfWeek.MONDAY))
+        runningFixture.createRunningRecord(user, startAt = targetDate.with(DayOfWeek.THURSDAY))
 
         // when & then
         RestAssured.given(spec).log().all()

--- a/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
@@ -72,9 +72,9 @@ class RecordDocumentTest : BaseDocumentTest() {
         val now = TimeProvider.now()
         val user = userFixture.create()
 
-        runningFixture.createRunningRecord(userId = user.id, startAt = now, totalSeconds = 60 * 20L)
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.plusDays(1), totalSeconds = 60 * 20L)
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.plusDays(2), totalSeconds = 60 * 20L)
+        runningFixture.createRunningRecord(user = user, startAt = now, totalSeconds = 60 * 20L)
+        runningFixture.createRunningRecord(user = user, startAt = now.plusDays(1), totalSeconds = 60 * 20L)
+        runningFixture.createRunningRecord(user = user, startAt = now.plusDays(2), totalSeconds = 60 * 20L)
 
         // when & then
         RestAssured.given(spec).log().all()
@@ -148,7 +148,7 @@ class RecordDocumentTest : BaseDocumentTest() {
         val user = userFixture.create()
         val runningRecord =
             runningFixture.createRunningRecord(
-                userId = user.id,
+                user = user,
                 totalSeconds = 60 * 20L,
             )
         val recordId = runningRecord.id
@@ -184,7 +184,7 @@ class RecordDocumentTest : BaseDocumentTest() {
         val user = userFixture.create()
         val runningRecord =
             runningFixture.createRunningRecord(
-                userId = user.id,
+                user = user,
                 totalSeconds = 60 * 20L,
             )
         val recordId = runningRecord.id

--- a/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
@@ -24,10 +24,11 @@ class RunningRecordControllerTest : BaseControllerTest() {
         // given
         val now = TimeProvider.now().toStartOfDay()
         val user = userFixture.create()
+        val otherUser = userFixture.create(email = "otherUser@email.com")
 
-        runningFixture.createRunningRecord(userId = user.id, startAt = now)
-        runningFixture.createRunningRecord(userId = 999L, startAt = now)
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.plusDays(1))
+        runningFixture.createRunningRecord(user = user, startAt = now)
+        runningFixture.createRunningRecord(user = otherUser, startAt = now)
+        runningFixture.createRunningRecord(user = user, startAt = now.plusDays(1))
 
         // when
         val result =
@@ -55,9 +56,9 @@ class RunningRecordControllerTest : BaseControllerTest() {
         val now = TimeProvider.now().with(DayOfWeek.MONDAY)
         val user = userFixture.create()
 
-        runningFixture.createRunningRecord(userId = user.id, startAt = now)
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.plusDays(2))
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.minusDays(8))
+        runningFixture.createRunningRecord(user = user, startAt = now)
+        runningFixture.createRunningRecord(user = user, startAt = now.plusDays(2))
+        runningFixture.createRunningRecord(user = user, startAt = now.minusDays(8))
 
         // when
         val result =
@@ -85,9 +86,9 @@ class RunningRecordControllerTest : BaseControllerTest() {
         val now = TimeProvider.now().toStartOfDay()
         val user = userFixture.create()
 
-        runningFixture.createRunningRecord(userId = user.id, startAt = now)
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.plusMonths(2))
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.minusYears(1))
+        runningFixture.createRunningRecord(user = user, startAt = now)
+        runningFixture.createRunningRecord(user = user, startAt = now.plusMonths(2))
+        runningFixture.createRunningRecord(user = user, startAt = now.minusYears(1))
 
         // when
         val result =
@@ -115,9 +116,9 @@ class RunningRecordControllerTest : BaseControllerTest() {
         val now = TimeProvider.now().toStartOfDay().withHour(0)
         val user = userFixture.create()
 
-        runningFixture.createRunningRecord(userId = user.id, startAt = now)
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.plusHours(2))
-        runningFixture.createRunningRecord(userId = user.id, startAt = now.minusHours(2))
+        runningFixture.createRunningRecord(user = user, startAt = now)
+        runningFixture.createRunningRecord(user = user, startAt = now.plusHours(2))
+        runningFixture.createRunningRecord(user = user, startAt = now.minusHours(2))
 
         // when
         val result =
@@ -146,7 +147,7 @@ class RunningRecordControllerTest : BaseControllerTest() {
         val user = userFixture.create()
         val runningRecord =
             runningFixture.createRunningRecord(
-                userId = user.id,
+                user = user,
                 startAt = now,
                 totalSeconds = 10L,
             )

--- a/src/test/kotlin/com/yapp/yapp/running/RunningMetricsCalculatorTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/running/RunningMetricsCalculatorTest.kt
@@ -20,7 +20,8 @@ class RunningMetricsCalculatorTest : BaseServiceTest() {
     @Test
     fun `거리를 계산한다`() {
         // given
-        val runningRecord = RunningRecord()
+        val user = userFixture.create()
+        val runningRecord = RunningRecord(user = user)
         val pointA =
             RunningPoint(
                 runningRecord = runningRecord,
@@ -46,7 +47,8 @@ class RunningMetricsCalculatorTest : BaseServiceTest() {
     @Test
     fun `두 좌표 사이의 거리를 계산한다`() {
         // given
-        val runningRecord = RunningRecord()
+        val user = userFixture.create()
+        val runningRecord = RunningRecord(user = user)
         val pointA =
             RunningPoint(
                 runningRecord = runningRecord,
@@ -72,7 +74,8 @@ class RunningMetricsCalculatorTest : BaseServiceTest() {
     @Test
     fun `속도를 계산한다`() {
         // given
-        val runningRecord = RunningRecord()
+        val user = userFixture.create()
+        val runningRecord = RunningRecord(user = user)
         val pointA =
             RunningPoint(
                 runningRecord = runningRecord,
@@ -98,7 +101,8 @@ class RunningMetricsCalculatorTest : BaseServiceTest() {
     @Test
     fun `fixture를 통해 속도와 거리를 계산한다`() {
         // given
-        val runningRecord = runningFixture.createRunningRecord()
+        val user = userFixture.create()
+        val runningRecord = runningFixture.createRunningRecord(user)
         val runningPoints = runningPointDao.getAllPointByRunningRecord(runningRecord)
         runningRecord.updateInfoByRunningPoints(runningPoints)
 

--- a/src/test/kotlin/com/yapp/yapp/running/RunningServiceTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/running/RunningServiceTest.kt
@@ -27,10 +27,11 @@ class RunningServiceTest : BaseServiceTest() {
     @Test
     fun `러닝을 시작한다`() {
         // given
+        val user = userFixture.create()
         val request = RunningStartRequest(0.0, 0.0, TimeProvider.now().toString())
 
         // when
-        val response = runningService.start(0L, request)
+        val response = runningService.start(userId = user.id, request)
 
         // then
         Assertions.assertThat(response.recordId).isNotNull
@@ -39,7 +40,8 @@ class RunningServiceTest : BaseServiceTest() {
     @Test
     fun `러닝 기록을 업데이트 한다`() {
         // given
-        val userId = 0L
+        val user = userFixture.create()
+        val userId = user.id
         val startResponse = runningService.start(userId, RunningStartRequest(0.0, 0.0, TimeProvider.now().toString()))
         val request =
             RunningUpdateRequest(
@@ -123,7 +125,8 @@ class RunningServiceTest : BaseServiceTest() {
     @Test
     fun `러닝을 시작 - 중단 - 완료 한다`() {
         // given
-        val userId = userFixture.create().id
+        val user = userFixture.create()
+        val userId = user.id
         val lat = 37.54100
         val lon = 126.95000
         val startAt = TimeProvider.now()
@@ -151,14 +154,15 @@ class RunningServiceTest : BaseServiceTest() {
         val done = runningService.done(userId, recordId, RunningDoneRequest(startAt.plusSeconds(doneTime).toString()))
 
         // then
-        val record = runningRecordManager.getRunningRecord(userId, recordId)
+        val record = runningRecordManager.getRunningRecord(id = recordId, user = user)
         Assertions.assertThat(record.totalDistance).isEqualTo(done.totalRunningDistance)
     }
 
     @Test
     fun `러닝 포인트가 추가될 때 마다 기록이 변한다`() {
         // given
-        val userId = userFixture.create().id
+        val user = userFixture.create()
+        val userId = user.id
         val startLat = 37.54100
         val startLon = 126.95000
         val startAt = TimeProvider.now()
@@ -184,7 +188,7 @@ class RunningServiceTest : BaseServiceTest() {
         var count = 0
         updates.forEach { request ->
             val response = runningService.update(userId, start.recordId, request)
-            val record = runningRecordManager.getRunningRecord(userId, start.recordId)
+            val record = runningRecordManager.getRunningRecord(id = start.recordId, user = user)
             count++
 
             Assertions.assertThat(record.totalDistance).isGreaterThan(14.19 * count)

--- a/src/test/kotlin/com/yapp/yapp/support/fixture/RunningFixture.kt
+++ b/src/test/kotlin/com/yapp/yapp/support/fixture/RunningFixture.kt
@@ -7,6 +7,7 @@ import com.yapp.yapp.record.domain.point.RunningPoint
 import com.yapp.yapp.record.domain.point.RunningPointRepository
 import com.yapp.yapp.record.domain.record.RunningRecord
 import com.yapp.yapp.record.domain.record.RunningRecordRepository
+import com.yapp.yapp.user.domain.User
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.OffsetDateTime
@@ -17,7 +18,7 @@ class RunningFixture(
     private val runningPointRepository: RunningPointRepository,
 ) {
     fun createRunningRecord(
-        userId: Long = 0L,
+        user: User,
         totalSeconds: Long = 9,
         startAt: OffsetDateTime = TimeProvider.parse("2025-06-17T17:00:00.000+09:00"),
     ): RunningRecord {
@@ -25,7 +26,7 @@ class RunningFixture(
         val runningRecord =
             runningRecordRepository.save(
                 RunningRecord(
-                    userId = userId,
+                    user = user,
                     startAt = startAt,
                 ),
             )

--- a/src/test/kotlin/com/yapp/yapp/support/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/yapp/yapp/support/fixture/UserFixture.kt
@@ -1,6 +1,7 @@
 package com.yapp.yapp.support.fixture
 
 import com.yapp.yapp.auth.infrastructure.provider.ProviderType
+import com.yapp.yapp.user.domain.NicknameGenerator
 import com.yapp.yapp.user.domain.RunnerType
 import com.yapp.yapp.user.domain.User
 import com.yapp.yapp.user.domain.UserRepository
@@ -11,14 +12,13 @@ class UserFixture(
     private val userRepository: UserRepository,
 ) {
     fun create(
-        nickname: String = "test nickname",
         email: String = "test email",
         provider: ProviderType = ProviderType.APPLE,
         runnerType: RunnerType = RunnerType.BEGINNER,
     ): User =
         userRepository.save(
             User(
-                nickname = nickname,
+                nickname = NicknameGenerator.generate(email),
                 email = email,
                 provider = provider,
                 runnerType = runnerType,

--- a/src/test/kotlin/com/yapp/yapp/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/user/UserServiceTest.kt
@@ -29,7 +29,7 @@ class UserServiceTest : BaseServiceTest() {
         // given
         val runnerType = RunnerType.BEGINNER
         val user = userFixture.create(runnerType = runnerType)
-        runningFixture.createRunningRecord(userId = user.id, totalSeconds = 60 * 20)
+        runningFixture.createRunningRecord(user = user, totalSeconds = 60 * 20)
 
         // when
         val recommendPace = userService.getRecommendPace(user.id)


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 143

## 📄 추가 작업 내용
-


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항
[이전](https://github.com/YAPP-Github/26th-App-Team-4-BE/pull/33#discussion_r2182558767)에 논의했듯이 엔티티가 userId를 가지고 있는 것이 아닌 엔티티를 가지도록 수정했습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터링**
  * 러닝 기록 관련 기능에서 사용자 정보를 ID가 아닌 사용자 객체로 일원화하여 처리하도록 개선되었습니다.
  * 서비스, 매니저, DAO, 리포지토리 등에서 사용자 ID 대신 사용자 객체를 직접 사용하도록 변경되었습니다.

* **테스트**
  * 테스트 코드 전반에서 러닝 기록 생성 시 사용자 객체를 직접 전달하도록 수정되었습니다.
  * 사용자 및 러닝 기록 관련 테스트 유틸 함수의 파라미터가 변경되었습니다.

* **기타**
  * 테스트용 사용자 생성 시 닉네임 파라미터가 제거되고, 이메일 기반 자동 생성으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->