### PR TITLE
feat: 기록 리스트 조회 시 이미지 url 포함 (FITRUN-176)

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordResponse.kt
@@ -14,7 +14,7 @@ data class RunningRecordResponse(
     val totalCalories: Int,
     val startAt: OffsetDateTime,
     val averagePace: Long,
-    val imageUrl: String?,
+    val imageUrl: String,
 ) {
     constructor(runningRecord: RunningRecord, runningPoints: List<RunningPoint>) : this(
         recordId = runningRecord.id,

--- a/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordSummaryResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordSummaryResponse.kt
@@ -9,6 +9,7 @@ data class RunningRecordSummaryResponse(
     val averagePace: Long,
     val totalDistance: Double,
     val totalTime: Long,
+    val imageUrl: String?,
 ) {
     constructor(runningRecordResponse: RunningRecordResponse) : this(
         recordId = runningRecordResponse.recordId,
@@ -17,5 +18,6 @@ data class RunningRecordSummaryResponse(
         averagePace = runningRecordResponse.averagePace,
         totalDistance = runningRecordResponse.totalDistance,
         totalTime = runningRecordResponse.totalTime,
+        imageUrl = runningRecordResponse.imageUrl,
     )
 }

--- a/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordSummaryResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordSummaryResponse.kt
@@ -9,7 +9,7 @@ data class RunningRecordSummaryResponse(
     val averagePace: Long,
     val totalDistance: Double,
     val totalTime: Long,
-    val imageUrl: String?,
+    val imageUrl: String,
 ) {
     constructor(runningRecordResponse: RunningRecordResponse) : this(
         recordId = runningRecordResponse.recordId,

--- a/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecord.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/record/RunningRecord.kt
@@ -43,8 +43,8 @@ class RunningRecord(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var recordStatus: RecordStatus = RecordStatus.READY,
-    @Column(nullable = true, columnDefinition = "TEXT")
-    var imageUrl: String? = null,
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var imageUrl: String = "",
     @Column(nullable = false)
     var isDeleted: Boolean = false,
 ) {

--- a/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
@@ -50,6 +50,7 @@ class RecordDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.records[].totalTime").description("총 러닝 시간 밀리초 단위"),
                     fieldWithPath("result.records[].startAt").description("러닝 시작 시간"),
                     fieldWithPath("result.records[].averagePace").description("평균 페이스 밀리초 단위"),
+                    fieldWithPath("result.records[].imageUrl").description("러닝 기록 지도 이미지 URL"),
                     fieldWithPath("result.userId").description("유저 ID"),
                     fieldWithPath("result.records").description("러닝 기록 리스트"),
                     fieldWithPath("result.recordCount").description("러닝 기록 개수"),
@@ -58,7 +59,7 @@ class RecordDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.totalCalories").description("총 소모 칼로리"),
                     fieldWithPath("result.averagePace").description("평균 페이스 밀리초 단위"),
                     fieldWithPath("result.timeGoalAchievedCount").description("시간 목표 달성 횟수"),
-                    fieldWithPath("result.distanceGoalAchievedCount").description("거리 목표 달성 횟수"),
+                    fieldWithPath("result.distanceGoalAchievedCount").description("러닝 경로 이미지 URL").optional(),
                 )
 
         val filter =
@@ -134,7 +135,7 @@ class RecordDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.totalCalories").description("총 소모 칼로리"),
                     fieldWithPath("result.startAt").description("시작 시간"),
                     fieldWithPath("result.averagePace").description("평균 페이스 밀리초 단위"),
-                    fieldWithPath("result.imageUrl").description("러닝 경로 이미지 URL"),
+                    fieldWithPath("result.imageUrl").description("러닝 경로 이미지 URL").optional(),
                 )
 
         val filter =

--- a/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
@@ -59,7 +59,7 @@ class RecordDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.totalCalories").description("총 소모 칼로리"),
                     fieldWithPath("result.averagePace").description("평균 페이스 밀리초 단위"),
                     fieldWithPath("result.timeGoalAchievedCount").description("시간 목표 달성 횟수"),
-                    fieldWithPath("result.distanceGoalAchievedCount").description("러닝 경로 이미지 URL").optional(),
+                    fieldWithPath("result.distanceGoalAchievedCount").description("러닝 경로 이미지 URL"),
                 )
 
         val filter =
@@ -135,7 +135,7 @@ class RecordDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.totalCalories").description("총 소모 칼로리"),
                     fieldWithPath("result.startAt").description("시작 시간"),
                     fieldWithPath("result.averagePace").description("평균 페이스 밀리초 단위"),
-                    fieldWithPath("result.imageUrl").description("러닝 경로 이미지 URL").optional(),
+                    fieldWithPath("result.imageUrl").description("러닝 경로 이미지 URL"),
                 )
 
         val filter =

--- a/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
@@ -59,7 +59,7 @@ class RecordDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.totalCalories").description("총 소모 칼로리"),
                     fieldWithPath("result.averagePace").description("평균 페이스 밀리초 단위"),
                     fieldWithPath("result.timeGoalAchievedCount").description("시간 목표 달성 횟수"),
-                    fieldWithPath("result.distanceGoalAchievedCount").description("러닝 경로 이미지 URL"),
+                    fieldWithPath("result.distanceGoalAchievedCount").description("거리 목표 달성 횟수"),
                 )
 
         val filter =


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 176

## 📄 추가 작업 내용
-


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항
기록 리스트 조회 시 이미지 URL를 포함해야했는데 누락되고 있었습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 러닝 기록 요약 응답에 러닝 경로 이미지 URL(`imageUrl`)이 추가되었습니다.

* **버그 수정**
  * 러닝 기록 관련 API 응답에서 이미지 URL 필드가 항상 값이 존재하도록 개선되었습니다.

* **문서**
  * 러닝 기록 리스트 조회 API 문서에 `imageUrl` 필드 설명이 추가 및 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->