### PR TITLE
fix: 목표없는 기록 조회(Fitrun 186)

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordListResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordListResponse.kt
@@ -11,7 +11,7 @@ data class RunningRecordListResponse(
     val timeGoalAchievedCount: Int,
     val distanceGoalAchievedCount: Int,
 ) {
-    constructor(userId: Long, records: List<RunningRecordResponse>, timeGoalAchievedCount: Int, distanceGoalAchievedCount: Int) : this(
+    constructor(userId: Long, records: List<RunningRecordResponse>, timeGoalAchievedCount: Int = 0, distanceGoalAchievedCount: Int = 0) : this(
         userId = userId,
         records = records.map { RunningRecordSummaryResponse(it) },
         recordCount = records.size,

--- a/src/main/kotlin/com/yapp/yapp/record/domain/RunningRecordService.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/RunningRecordService.kt
@@ -43,17 +43,22 @@ class RunningRecordService(
                 targetDate = targetDate,
                 pageable = pageable,
             )
-        val userGoal = userGoalManager.getUserGoal(user)
-        val timeGoalAchievedCount = runningRecords.count { userGoal.isTimeGoalAchieved(it) }
-        val distanceGoalAchievedCount = runningRecords.count { userGoal.isDistanceGoalAchieved(it) }
         val runningRecordResponse =
             runningRecords.map { RunningRecordResponse(it, pointManager.getRunningPoints(it)) }
-
+        if (userGoalManager.hasUserGoal(user)) {
+            val userGoal = userGoalManager.getUserGoal(user)
+            val timeGoalAchievedCount = runningRecords.count { userGoal.isTimeGoalAchieved(it) }
+            val distanceGoalAchievedCount = runningRecords.count { userGoal.isDistanceGoalAchieved(it) }
+            return RunningRecordListResponse(
+                userId = user.id,
+                records = runningRecordResponse,
+                timeGoalAchievedCount = timeGoalAchievedCount,
+                distanceGoalAchievedCount = distanceGoalAchievedCount,
+            )
+        }
         return RunningRecordListResponse(
             userId = user.id,
             records = runningRecordResponse,
-            timeGoalAchievedCount = timeGoalAchievedCount,
-            distanceGoalAchievedCount = distanceGoalAchievedCount,
         )
     }
 

--- a/src/main/kotlin/com/yapp/yapp/user/domain/goal/UserGoalManager.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/domain/goal/UserGoalManager.kt
@@ -71,6 +71,10 @@ class UserGoalManager(
         return userGoalDao.getUserGoal(user)
     }
 
+    fun hasUserGoal(user: User): Boolean {
+        return userGoalDao.findUserGoal(user) != null
+    }
+
     fun calculateRecommendPace(
         runnerType: RunnerType,
         recentRunningRecord: RunningRecord?,

--- a/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/record/RecordDocumentTest.kt
@@ -26,7 +26,7 @@ class RecordDocumentTest : BaseDocumentTest() {
                 )
                 .queryParameter(
                     parameterWithName("type")
-                        .description("검색 타입 (ALL, TODAY 등). 기본값 ALL")
+                        .description("검색 타입 (ALL, DAILY, WEEKLY, MONTHLY, YEARLY). 기본값 ALL")
                         .optional(),
                     parameterWithName("targetDate")
                         .description("조회 기준 날짜 (ISO-8601 문자열), 기본값 현재 시각")
@@ -36,7 +36,7 @@ class RecordDocumentTest : BaseDocumentTest() {
                     parameterWithName("size")
                         .description("페이지 크기").optional(),
                     parameterWithName("sort")
-                        .description("정렬 기준 (ex: createdAt,DESC)").optional(),
+                        .description("정렬 기준입니다. 기본적으로 러닝 시작일 기준 내림차순입니다. 생략해도 됩니다. (ex: startAt,DESC)").optional(),
                 )
 
         val restDocsResponse =
@@ -85,6 +85,7 @@ class RecordDocumentTest : BaseDocumentTest() {
             .param("targetDate", now.toString())
             .param("page", 0)
             .param("size", 10)
+            .param("sort", "startAt,DESC")
             .`when`()
             .get("/api/v1/records")
             .then().log().all()

--- a/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
@@ -194,7 +194,10 @@ class RunningRecordControllerTest : BaseControllerTest() {
 
     @ParameterizedTest
     @CsvSource("0,10", "1,10", "2,5")
-    fun `유저의 러닝 기록 리스트를 페이지 단위로 조회한다`(page: Int, size: Int) {
+    fun `유저의 러닝 기록 리스트를 페이지 단위로 조회한다`(
+        page: Int,
+        size: Int,
+    ) {
         // given
         val now = TimeProvider.now().toStartOfDay()
         val user = userFixture.createWithGoal()

--- a/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
@@ -193,10 +193,11 @@ class RunningRecordControllerTest : BaseControllerTest() {
     }
 
     @ParameterizedTest
-    @CsvSource("0,10", "1,10", "2,5")
+    @CsvSource("0,10,10", "1,10,10", "2,10,5", "0,5,5")
     fun `유저의 러닝 기록 리스트를 페이지 단위로 조회한다`(
         page: Int,
         size: Int,
+        expectedSize: Int,
     ) {
         // given
         val now = TimeProvider.now().toStartOfDay()
@@ -211,7 +212,7 @@ class RunningRecordControllerTest : BaseControllerTest() {
                 .param("type", RecordsSearchType.ALL.name)
                 .param("targetDate", now.toString())
                 .param("page", page)
-                .param("size", 10)
+                .param("size", size)
                 .`when`()
                 .get("/api/v1/records")
                 .then().log().all()
@@ -221,6 +222,6 @@ class RunningRecordControllerTest : BaseControllerTest() {
         val response = convert(result, RunningRecordListResponse::class.java)
 
         // then
-        Assertions.assertThat(response.records.size).isEqualTo(size)
+        Assertions.assertThat(response.records.size).isEqualTo(expectedSize)
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: [FITRUN 186](https://fitrun.atlassian.net/browse/FITRUN-186)

## 📄 추가 작업 내용
- 


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [X] Label을 지정했나요?


## 💬 기타 참고 사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자가 목표를 설정하지 않은 경우에도 러닝 기록 리스트를 정상적으로 조회할 수 있도록 개선되었습니다.
  * 사용자 목표 존재 여부를 확인하는 기능이 추가되었습니다.
  * 러닝 기록 리스트 응답 시 목표 달성 카운트가 기본값 0으로 설정되어, 관련 정보가 없을 때도 안정적으로 데이터를 제공합니다.

* **Bug Fixes**
  * 목표가 없는 사용자의 러닝 기록 조회 시 불필요한 목표 달성 관련 정보가 포함되지 않도록 수정되었습니다.

* **Tests**
  * 목표가 없는 사용자의 러닝 기록 리스트 조회에 대한 테스트가 추가되었습니다.
  * 유저의 러닝 기록 리스트 조회 관련 테스트 메서드 이름이 더 명확하게 변경되었습니다.
  * 러닝 기록 리스트의 페이징 조회에 대한 파라미터화 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->