### PR TITLE
feat: 러닝 기록 이미지 저장 API 분리(FITRUN-193)

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/running/api/RunningController.kt
+++ b/src/main/kotlin/com/yapp/yapp/running/api/RunningController.kt
@@ -10,6 +10,7 @@ import com.yapp.yapp.running.api.request.RunningStartRequest
 import com.yapp.yapp.running.api.response.RunningPollingDoneResponse
 import com.yapp.yapp.running.api.response.RunningPollingPauseResponse
 import com.yapp.yapp.running.api.response.RunningPollingUpdateResponse
+import com.yapp.yapp.running.api.response.RunningRecordImageResponse
 import com.yapp.yapp.running.api.response.RunningStartResponse
 import com.yapp.yapp.running.domain.RunningService
 import org.springframework.web.bind.annotation.PatchMapping
@@ -38,17 +39,30 @@ class RunningController(
     fun done(
         @CurrentUser userId: Long,
         @PathVariable recordId: Long,
-        @RequestPart("metadata") request: RunningDoneRequest,
-        @RequestPart("image") imageFile: MultipartFile,
+        @RequestBody request: RunningDoneRequest,
     ): ApiResponse<RunningRecordResponse> {
         val recordResponse =
             runningService.done(
                 userId = userId,
                 recordId = recordId,
                 request = request,
-                imageFile = imageFile,
             )
         return ApiResponse.success(recordResponse)
+    }
+
+    @PostMapping("/{recordId}/images")
+    fun uploadRecordImage(
+        @CurrentUser userId: Long,
+        @PathVariable recordId: Long,
+        @RequestPart("image") imageFile: MultipartFile,
+    ): ApiResponse<RunningRecordImageResponse> {
+        val imageResponse =
+            runningService.uploadRecordImage(
+                userId = userId,
+                recordId = recordId,
+                imageFile = imageFile,
+            )
+        return ApiResponse.success(imageResponse)
     }
 
     @PostMapping("/{recordId}/polling")

--- a/src/main/kotlin/com/yapp/yapp/running/api/response/RunningRecordImageResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/running/api/response/RunningRecordImageResponse.kt
@@ -1,0 +1,7 @@
+package com.yapp.yapp.running.api.response
+
+data class RunningRecordImageResponse(
+    val userId: Long,
+    val recordId: Long,
+    val imageUrl: String,
+)

--- a/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
@@ -176,7 +176,6 @@ class RunningRecordControllerTest : BaseControllerTest() {
             userId = user.id,
             recordId = recordId,
             request = RequestFixture.runningDoneRequest(),
-            imageFile = runningFixture.multipartFile(),
         )
 
         // when

--- a/src/test/kotlin/com/yapp/yapp/running/RunningControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/running/RunningControllerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
 class RunningControllerTest : BaseControllerTest() {
     @Autowired
@@ -42,14 +43,12 @@ class RunningControllerTest : BaseControllerTest() {
         val startResponse = runningService.start(user.id, RequestFixture.runningStartRequest())
         val recordId = startResponse.recordId
         val request = RequestFixture.runningDoneRequest()
-        val testImageFile = runningFixture.file()
 
         // when
         RestAssured.given().log().all()
             .header(HttpHeaders.AUTHORIZATION, getAccessToken(user.email))
-            .contentType("multipart/form-data")
-            .multiPart("metadata", objectMapper.writeValueAsString(request), "application/json")
-            .multiPart("image", testImageFile, "images/png")
+            .contentType(APPLICATION_JSON_VALUE)
+            .body(request)
             .pathParam("recordId", recordId)
             .`when`().post("/api/v1/running/{recordId}")
             .then().log().all()

--- a/src/test/kotlin/com/yapp/yapp/running/RunningServiceTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/running/RunningServiceTest.kt
@@ -209,7 +209,7 @@ class RunningServiceTest : BaseServiceTest() {
 
         // when & then
         Assertions.assertThatThrownBy {
-            runningService.done(userId = userId, recordId = recordId, request = request, imageFile = runningFixture.multipartFile())
+            runningService.done(userId = userId, recordId = recordId, request = request)
         }.isInstanceOf(CustomException::class.java)
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 193

## 📄 추가 작업 내용
-


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 러닝 기록 완료와 이미지 업로드를 분리하여, 러닝 기록 이미지 업로드 전용 엔드포인트가 추가되었습니다.
  * 러닝 기록 이미지 업로드 시 이미지 URL 정보를 포함한 응답을 제공합니다.

* **버그 수정**
  * 러닝 기록 완료 시 이미지 파일을 함께 전송하지 않도록 개선되었습니다.

* **테스트**
  * 러닝 기록 이미지 업로드 API에 대한 테스트 및 문서화가 추가되었습니다.
  * 기존 러닝 완료 및 관련 테스트가 새로운 API 구조에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->