### PR TITLE
feat: OIDC 갱신 스케줄러 추가(FITRUN-194)

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/auth/infrastructure/cache/CacheUpdateScheduler.kt
+++ b/src/main/kotlin/com/yapp/yapp/auth/infrastructure/cache/CacheUpdateScheduler.kt
@@ -1,0 +1,25 @@
+package com.yapp.yapp.auth.infrastructure.cache
+
+import com.yapp.yapp.auth.infrastructure.provider.apple.AppleApiClient
+import com.yapp.yapp.auth.infrastructure.provider.kakao.KakaoApiClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class CacheUpdateScheduler(
+    private val kakaoApiClient: KakaoApiClient,
+    private val appleApiClient: AppleApiClient,
+) {
+    private val logger = KotlinLogging.logger {}
+
+    @Scheduled(
+        initialDelayString = "\${oidc.initial-refresh-delay}",
+        fixedDelayString = "\${oidc.response-refresh-millis}",
+    )
+    fun refreshOidcProperties() {
+        kakaoApiClient.refreshOidcProperties()
+        appleApiClient.refreshOidcProperties()
+        logger.info { "[${java.time.Instant.now()}] Oidc Response 캐시 갱신 완료" }
+    }
+}

--- a/src/main/kotlin/com/yapp/yapp/auth/infrastructure/provider/apple/AppleApiClient.kt
+++ b/src/main/kotlin/com/yapp/yapp/auth/infrastructure/provider/apple/AppleApiClient.kt
@@ -3,6 +3,7 @@ package com.yapp.yapp.auth.infrastructure.provider.apple
 import com.yapp.yapp.auth.infrastructure.provider.ApiClient
 import com.yapp.yapp.common.cache.CacheNames
 import com.yapp.yapp.common.token.oidc.OidcProperties
+import org.springframework.cache.annotation.CachePut
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 
@@ -11,8 +12,17 @@ class AppleApiClient(
     private val appleProperties: AppleProperties,
     private val appleFeignClient: AppleFeignClient,
 ) : ApiClient {
-    @Cacheable(cacheNames = [CacheNames.API_RESPONSE], key = "'applePublicKeyResponse'")
-    override fun getOidcProperties(): OidcProperties {
+    companion object {
+        private const val CACHE_KEY = "'applePublicKeyResponse'"
+    }
+
+    @Cacheable(cacheNames = [CacheNames.API_RESPONSE], key = CACHE_KEY)
+    override fun getOidcProperties(): OidcProperties = fetchOidcProperties()
+
+    @CachePut(cacheNames = [CacheNames.API_RESPONSE], key = CACHE_KEY)
+    fun refreshOidcProperties(): OidcProperties = fetchOidcProperties()
+
+    private fun fetchOidcProperties(): OidcProperties {
         val jwkSet = appleFeignClient.fetchJwks()
         return OidcProperties(
             keySet = jwkSet,

--- a/src/main/kotlin/com/yapp/yapp/auth/infrastructure/provider/kakao/KakaoApiClient.kt
+++ b/src/main/kotlin/com/yapp/yapp/auth/infrastructure/provider/kakao/KakaoApiClient.kt
@@ -3,6 +3,7 @@ package com.yapp.yapp.auth.infrastructure.provider.kakao
 import com.yapp.yapp.auth.infrastructure.provider.ApiClient
 import com.yapp.yapp.common.cache.CacheNames
 import com.yapp.yapp.common.token.oidc.OidcProperties
+import org.springframework.cache.annotation.CachePut
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 
@@ -11,8 +12,17 @@ class KakaoApiClient(
     private val kakaoProperties: KakaoProperties,
     private val kakaoFeignClient: KakaoFeignClient,
 ) : ApiClient {
-    @Cacheable(cacheNames = [CacheNames.API_RESPONSE], key = "'kakaoPublicKeyResponse'")
-    override fun getOidcProperties(): OidcProperties {
+    companion object {
+        private const val CACHE_KEY = "'kakaoPublicKeyResponse'"
+    }
+
+    @Cacheable(cacheNames = [CacheNames.API_RESPONSE], key = CACHE_KEY)
+    override fun getOidcProperties(): OidcProperties = fetchOidcProperties()
+
+    @CachePut(cacheNames = [CacheNames.API_RESPONSE], key = CACHE_KEY)
+    fun refreshOidcProperties(): OidcProperties = fetchOidcProperties()
+
+    private fun fetchOidcProperties(): OidcProperties {
         val jwkSet = kakaoFeignClient.fetchJwks()
         return OidcProperties(
             keySet = jwkSet,

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -46,6 +46,8 @@ gcp:
 
 oidc:
   response-millis: 3600000
+  response-refresh-millis: 300000
+  initial-refresh-delay: 60000
   apple:
     api:
       url: https://appleid.apple.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,8 @@ jwt:
 
 oidc:
   response-millis: ${secret.oidc.response-millis}
+  response-refresh-millis: ${secret.oidc.response-refresh-millis}
+  initial-refresh-delay: ${secret.oidc.initial-refresh-delay}
   apple:
     api:
       url: ${secret.oidc.apple.url}


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 194

## 📄 추가 작업 내용
-


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항
부하 테스트 과정에서 캐시 스템피드 문제가 발생하는 것을 확인했습니다. 
관련해서[ 이전 공개키 조회 문제 문서화](https://www.notion.so/23484e88f65b8043a08ff083228baeed?source=copy_link)에 내용 추가해두었습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 외부 인증 제공자(Kakao, Apple)의 OIDC 정보 캐시가 주기적으로 자동 갱신됩니다.
  * OIDC 캐시 갱신 주기와 초기 지연 시간을 설정할 수 있는 환경설정 항목이 추가되었습니다.

* **Bug Fixes**
  * OIDC 정보 캐시 갱신 및 조회 동작이 분리되어 더욱 안정적으로 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->