### PR TITLE
feat: 목표 조회에 러너타입 추가 (Fitrun 199)

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/user/api/UserGoalController.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/api/UserGoalController.kt
@@ -9,6 +9,11 @@ import com.yapp.yapp.user.api.request.TimeGoalRequest
 import com.yapp.yapp.user.api.request.WeeklyRunCountGoalRequest
 import com.yapp.yapp.user.api.response.RecommendPaceResponse
 import com.yapp.yapp.user.api.response.UserGoalResponse
+import com.yapp.yapp.user.api.response.goal.DistanceGoalResponse
+import com.yapp.yapp.user.api.response.goal.PaceGoalResponse
+import com.yapp.yapp.user.api.response.goal.PurposeGoalResponse
+import com.yapp.yapp.user.api.response.goal.TimeGoalResponse
+import com.yapp.yapp.user.api.response.goal.WeeklyRunCountGoalResponse
 import com.yapp.yapp.user.domain.UserService
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,9 +34,10 @@ class UserGoalController(
     fun saveWeeklyRunCountGoal(
         @CurrentUser id: Long,
         @RequestBody request: WeeklyRunCountGoalRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<WeeklyRunCountGoalResponse> {
+        val userGoalResponse = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            WeeklyRunCountGoalResponse(userGoalResponse),
         )
     }
 
@@ -40,9 +46,10 @@ class UserGoalController(
     fun savePaceGoal(
         @CurrentUser id: Long,
         @RequestBody request: PaceGoalRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<PaceGoalResponse> {
+        val userGoalResponse = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            PaceGoalResponse(userGoalResponse),
         )
     }
 
@@ -51,9 +58,10 @@ class UserGoalController(
     fun saveDistanceGoal(
         @CurrentUser id: Long,
         @RequestBody request: DistanceGoalRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<DistanceGoalResponse> {
+        val userGoal = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            DistanceGoalResponse(userGoal),
         )
     }
 
@@ -62,9 +70,10 @@ class UserGoalController(
     fun saveTimeGoal(
         @CurrentUser id: Long,
         @RequestBody request: TimeGoalRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<TimeGoalResponse> {
+        val userGoal = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            TimeGoalResponse(userGoal),
         )
     }
 
@@ -73,9 +82,10 @@ class UserGoalController(
     fun saveRunningGoal(
         @CurrentUser id: Long,
         @RequestBody request: RunningPurposeRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<PurposeGoalResponse> {
+        val userGoal = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            PurposeGoalResponse(userGoal),
         )
     }
 
@@ -92,9 +102,12 @@ class UserGoalController(
     fun updateWeeklyRunCountGoal(
         @CurrentUser id: Long,
         @RequestBody request: WeeklyRunCountGoalRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<WeeklyRunCountGoalResponse> {
+        val userGoalResponse = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            WeeklyRunCountGoalResponse(
+                userGoalResponse,
+            ),
         )
     }
 
@@ -102,9 +115,10 @@ class UserGoalController(
     fun updatePaceGoal(
         @CurrentUser id: Long,
         @RequestBody request: PaceGoalRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<PaceGoalResponse> {
+        val userGoal = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            PaceGoalResponse(userGoal),
         )
     }
 
@@ -124,9 +138,10 @@ class UserGoalController(
     fun updateDistanceGoal(
         @CurrentUser id: Long,
         @RequestBody request: DistanceGoalRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<DistanceGoalResponse> {
+        val userGoal = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            DistanceGoalResponse(userGoal),
         )
     }
 
@@ -134,9 +149,10 @@ class UserGoalController(
     fun updateTimeGoal(
         @CurrentUser id: Long,
         @RequestBody request: TimeGoalRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<TimeGoalResponse> {
+        val userGoal = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            TimeGoalResponse(userGoal),
         )
     }
 
@@ -144,9 +160,10 @@ class UserGoalController(
     fun updateRunningGoal(
         @CurrentUser id: Long,
         @RequestBody request: RunningPurposeRequest,
-    ): ApiResponse<UserGoalResponse> {
+    ): ApiResponse<PurposeGoalResponse> {
+        val userGoal = UserGoalResponse(userService.upsertGoal(userId = id, request = request))
         return ApiResponse.success(
-            UserGoalResponse(userService.upsertGoal(userId = id, request = request)),
+            PurposeGoalResponse(userGoal),
         )
     }
 }

--- a/src/main/kotlin/com/yapp/yapp/user/api/response/UserGoalResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/api/response/UserGoalResponse.kt
@@ -1,5 +1,6 @@
 package com.yapp.yapp.user.api.response
 
+import com.yapp.yapp.user.domain.RunnerType
 import com.yapp.yapp.user.domain.goal.UserGoal
 
 data class UserGoalResponse(
@@ -10,6 +11,7 @@ data class UserGoalResponse(
     val paceGoal: Long? = null,
     val distanceMeterGoal: Double? = null,
     val timeGoal: Long? = null,
+    val runnerType: RunnerType? = null,
 ) {
     constructor(userGoal: UserGoal) : this(
         goalId = userGoal.id,
@@ -19,5 +21,6 @@ data class UserGoalResponse(
         paceGoal = userGoal.paceGoal?.toMills(),
         distanceMeterGoal = userGoal.distanceMeterGoal,
         timeGoal = userGoal.timeGoal,
+        runnerType = userGoal.user.runnerType,
     )
 }

--- a/src/main/kotlin/com/yapp/yapp/user/api/response/goal/DistanceGoalResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/api/response/goal/DistanceGoalResponse.kt
@@ -1,0 +1,15 @@
+package com.yapp.yapp.user.api.response.goal
+
+import com.yapp.yapp.user.api.response.UserGoalResponse
+
+data class DistanceGoalResponse(
+    val goalId: Long,
+    val userId: Long,
+    val distanceMeterGoal: Double,
+) {
+    constructor(userGoalResponse: UserGoalResponse) : this(
+        goalId = userGoalResponse.goalId,
+        userId = userGoalResponse.userId,
+        distanceMeterGoal = userGoalResponse.distanceMeterGoal as Double,
+    )
+}

--- a/src/main/kotlin/com/yapp/yapp/user/api/response/goal/PaceGoalResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/api/response/goal/PaceGoalResponse.kt
@@ -1,0 +1,15 @@
+package com.yapp.yapp.user.api.response.goal
+
+import com.yapp.yapp.user.api.response.UserGoalResponse
+
+class PaceGoalResponse(
+    val goalId: Long,
+    val userId: Long,
+    val paceGoal: Long,
+) {
+    constructor(userGoalResponse: UserGoalResponse) : this(
+        goalId = userGoalResponse.goalId,
+        userId = userGoalResponse.userId,
+        paceGoal = userGoalResponse.paceGoal as Long,
+    )
+}

--- a/src/main/kotlin/com/yapp/yapp/user/api/response/goal/PurposeGoalResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/api/response/goal/PurposeGoalResponse.kt
@@ -1,0 +1,15 @@
+package com.yapp.yapp.user.api.response.goal
+
+import com.yapp.yapp.user.api.response.UserGoalResponse
+
+data class PurposeGoalResponse(
+    val goalId: Long,
+    val userId: Long,
+    val runningPurpose: String,
+) {
+    constructor(userGoalResponse: UserGoalResponse) : this(
+        goalId = userGoalResponse.goalId,
+        userId = userGoalResponse.userId,
+        runningPurpose = userGoalResponse.runningPurpose as String,
+    )
+}

--- a/src/main/kotlin/com/yapp/yapp/user/api/response/goal/TimeGoalResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/api/response/goal/TimeGoalResponse.kt
@@ -1,0 +1,15 @@
+package com.yapp.yapp.user.api.response.goal
+
+import com.yapp.yapp.user.api.response.UserGoalResponse
+
+data class TimeGoalResponse(
+    val goalId: Long,
+    val userId: Long,
+    val timeGoal: Long,
+) {
+    constructor(userGoalResponse: UserGoalResponse) : this(
+        goalId = userGoalResponse.goalId,
+        userId = userGoalResponse.userId,
+        timeGoal = userGoalResponse.timeGoal as Long,
+    )
+}

--- a/src/main/kotlin/com/yapp/yapp/user/api/response/goal/WeeklyRunCountGoalResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/api/response/goal/WeeklyRunCountGoalResponse.kt
@@ -1,0 +1,15 @@
+package com.yapp.yapp.user.api.response.goal
+
+import com.yapp.yapp.user.api.response.UserGoalResponse
+
+data class WeeklyRunCountGoalResponse(
+    val goalId: Long,
+    val userId: Long,
+    val weeklyRunningCount: Int,
+) {
+    constructor(userGoalResponse: UserGoalResponse) : this(
+        goalId = userGoalResponse.goalId,
+        userId = userGoalResponse.userId,
+        weeklyRunningCount = userGoalResponse.weeklyRunningCount as Int,
+    )
+}

--- a/src/test/kotlin/com/yapp/yapp/document/user/UserDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/user/UserDocumentTest.kt
@@ -51,6 +51,7 @@ class UserDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.goal.paceGoal").description("페이스 목표 시간 밀리초 단위").type(JsonFieldType.NUMBER).optional(),
                     fieldWithPath("result.goal.distanceMeterGoal").description("거리 목표(m)").type(JsonFieldType.NUMBER).optional(),
                     fieldWithPath("result.goal.timeGoal").description("시간 목표 시간 밀리초 단위").type(JsonFieldType.NUMBER).optional(),
+                    fieldWithPath("result.goal.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -281,7 +282,7 @@ class UserDocumentTest : BaseDocumentTest() {
             response()
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runnerType").description("러너 유형(Enum). 초보: 워밍업, 중급: 루틴, 고급: 챌린저"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =

--- a/src/test/kotlin/com/yapp/yapp/document/user/UserDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/user/UserDocumentTest.kt
@@ -34,7 +34,7 @@ class UserDocumentTest : BaseDocumentTest() {
                         "사용자 러너 유형 (" +
                             "초보: BEGINNER, " +
                             "중급: INTERMEDIATE, " +
-                            "전문가: EXPORT )",
+                            "전문가: EXPERT )",
                     ).type(JsonFieldType.STRING)
                         .optional(),
                     fieldWithPath("result.goal").description("사용자의 목표 정보 (없을 경우 null)").optional(),
@@ -51,7 +51,7 @@ class UserDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.goal.paceGoal").description("페이스 목표 시간 밀리초 단위").type(JsonFieldType.NUMBER).optional(),
                     fieldWithPath("result.goal.distanceMeterGoal").description("거리 목표(m)").type(JsonFieldType.NUMBER).optional(),
                     fieldWithPath("result.goal.timeGoal").description("시간 목표 시간 밀리초 단위").type(JsonFieldType.NUMBER).optional(),
-                    fieldWithPath("result.goal.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
+                    fieldWithPath("result.goal.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPERT)"),
                 )
 
         val restDocsFilter =
@@ -282,7 +282,7 @@ class UserDocumentTest : BaseDocumentTest() {
             response()
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPERT)"),
                 )
 
         val restDocsFilter =

--- a/src/test/kotlin/com/yapp/yapp/document/user/UserGoalDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/user/UserGoalDocumentTest.kt
@@ -33,18 +33,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.goalId").description("목표 ID"),
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runningPurpose").description(
-                        "달리기 목적 (" +
-                            "다이어트: WEIGHT_LOSS_PURPOSE, " +
-                            "건강 유지: HEALTH_MAINTENANCE_PURPOSE, " +
-                            "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
-                            "대회 준비: COMPETITION_PREPARATION",
-                    ),
                     fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
-                    fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
-                    fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -56,7 +45,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -87,18 +76,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.goalId").description("목표 ID"),
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runningPurpose").description(
-                        "달리기 목적 (" +
-                            "다이어트: WEIGHT_LOSS_PURPOSE, " +
-                            "건강 유지: HEALTH_MAINTENANCE_PURPOSE, " +
-                            "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
-                            "대회 준비: COMPETITION_PREPARATION",
-                    ),
-                    fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
-                    fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -110,7 +88,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -141,18 +119,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.goalId").description("목표 ID"),
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runningPurpose").description(
-                        "달리기 목적 (" +
-                            "다이어트: WEIGHT_LOSS_PURPOSE, " +
-                            "건강 유지: HEALTH_MAINTENANCE_PURPOSE, " +
-                            "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
-                            "대회 준비: COMPETITION_PREPARATION",
-                    ),
-                    fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
-                    fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
-                    fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -164,7 +131,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -195,18 +162,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.goalId").description("목표 ID"),
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runningPurpose").description(
-                        "달리기 목적 (" +
-                            "다이어트: WEIGHT_LOSS_PURPOSE, " +
-                            "건강 유지: HEALTH_MAINTENANCE_PURPOSE, " +
-                            "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
-                            "대회 준비: COMPETITION_PREPARATION",
-                    ),
-                    fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
-                    fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -218,7 +174,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -262,11 +218,6 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                             "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
                             "대회 준비: COMPETITION_PREPARATION",
                     ),
-                    fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
-                    fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
-                    fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -278,7 +229,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -329,7 +280,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
         userGoalFixture.create(user)
 
         // when
@@ -398,18 +349,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.goalId").description("목표 ID"),
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runningPurpose").description(
-                        "달리기 목적 (" +
-                            "다이어트: WEIGHT_LOSS_PURPOSE, " +
-                            "건강 유지: HEALTH_MAINTENANCE_PURPOSE, " +
-                            "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
-                            "대회 준비: COMPETITION_PREPARATION",
-                    ),
                     fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
-                    fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
-                    fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -421,7 +361,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -452,18 +392,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.goalId").description("목표 ID"),
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runningPurpose").description(
-                        "달리기 목적 (" +
-                            "다이어트: WEIGHT_LOSS_PURPOSE, " +
-                            "건강 유지: HEALTH_MAINTENANCE_PURPOSE, " +
-                            "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
-                            "대회 준비: COMPETITION_PREPARATION",
-                    ),
-                    fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
-                    fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -475,7 +404,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -506,18 +435,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.goalId").description("목표 ID"),
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runningPurpose").description(
-                        "달리기 목적 (" +
-                            "다이어트: WEIGHT_LOSS_PURPOSE, " +
-                            "건강 유지: HEALTH_MAINTENANCE_PURPOSE, " +
-                            "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
-                            "대회 준비: COMPETITION_PREPARATION",
-                    ),
-                    fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
-                    fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
-                    fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -529,7 +447,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -560,18 +478,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .responseBodyFieldWithResult(
                     fieldWithPath("result.goalId").description("목표 ID"),
                     fieldWithPath("result.userId").description("사용자 ID"),
-                    fieldWithPath("result.runningPurpose").description(
-                        "달리기 목적 (" +
-                            "다이어트: WEIGHT_LOSS_PURPOSE, " +
-                            "건강 유지: HEALTH_MAINTENANCE_PURPOSE, " +
-                            "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
-                            "대회 준비: COMPETITION_PREPARATION",
-                    ),
-                    fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
-                    fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -583,7 +490,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then
@@ -627,11 +534,6 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                             "체력 증진: DAILY_STRENGTH_IMPROVEMENT, " +
                             "대회 준비: COMPETITION_PREPARATION",
                     ),
-                    fieldWithPath("result.weeklyRunningCount").description("주간 달리기 횟수"),
-                    fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
-                    fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -643,7 +545,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create(runnerType = null)
+        val user = userFixture.create()
 
         // when
         // then

--- a/src/test/kotlin/com/yapp/yapp/document/user/UserGoalDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/user/UserGoalDocumentTest.kt
@@ -268,7 +268,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
-                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPERT)"),
                 )
 
         val restDocsFilter =

--- a/src/test/kotlin/com/yapp/yapp/document/user/UserGoalDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/user/UserGoalDocumentTest.kt
@@ -44,6 +44,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -55,7 +56,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -97,6 +98,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -108,7 +110,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -150,6 +152,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -161,7 +164,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -203,6 +206,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -214,7 +218,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -262,6 +266,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -273,7 +278,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -312,6 +317,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -323,7 +329,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
         userGoalFixture.create(user)
 
         // when
@@ -403,6 +409,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -414,7 +421,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -456,6 +463,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -467,7 +475,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -509,6 +517,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -520,7 +529,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -562,6 +571,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -573,7 +583,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then
@@ -621,6 +631,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                     fieldWithPath("result.paceGoal").description("페이스 목표 시간 밀리초 단위"),
                     fieldWithPath("result.distanceMeterGoal").description("거리 목표(m)"),
                     fieldWithPath("result.timeGoal").description("시간 목표 시간 밀리초 단위"),
+                    fieldWithPath("result.runnerType").description("러너 타입(초보: BEGINNER, 중급: INTERMEDIATE, 전문가: EXPORT)"),
                 )
 
         val restDocsFilter =
@@ -632,7 +643,7 @@ class UserGoalDocumentTest : BaseDocumentTest() {
                 .response(restDocsResponse)
                 .build()
 
-        val user = userFixture.create()
+        val user = userFixture.create(runnerType = null)
 
         // when
         // then

--- a/src/test/kotlin/com/yapp/yapp/support/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/yapp/yapp/support/fixture/UserFixture.kt
@@ -19,7 +19,7 @@ class UserFixture(
     fun create(
         email: String = "test email",
         provider: ProviderType = ProviderType.APPLE,
-        runnerType: RunnerType = RunnerType.BEGINNER,
+        runnerType: RunnerType? = RunnerType.BEGINNER,
     ): User =
         userRepository.save(
             User(

--- a/src/test/kotlin/com/yapp/yapp/support/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/yapp/yapp/support/fixture/UserFixture.kt
@@ -19,7 +19,7 @@ class UserFixture(
     fun create(
         email: String = "test email",
         provider: ProviderType = ProviderType.APPLE,
-        runnerType: RunnerType? = RunnerType.BEGINNER,
+        runnerType: RunnerType = RunnerType.BEGINNER,
     ): User =
         userRepository.save(
             User(


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 199

## 📄 추가 작업 내용
-


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 목표 관련 API가 유형별 응답으로 세분화되어(주간횟수, 페이스, 거리, 시간, 목적) 반환됩니다.
  * 사용자 목표 조회 결과에 러너 타입(runnerType) 정보가 추가되었습니다.
* **Documentation**
  * 사용자/목표 API 문서에 runnerType 필드를 추가하고 설명을 업데이트했습니다.
  * 목표 관련 API 문서에서 불필요한 응답 필드를 정리했습니다.
* **Chores**
  * 서브모듈 참조를 최신 커밋으로 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->