### PR TITLE
infra: node exporter 설치 (FITRUN-200)

### DIFF
--- a/deployment/staging/deploy.sh
+++ b/deployment/staging/deploy.sh
@@ -19,6 +19,7 @@ BLUE_CONTAINER="fitrun-blue"
 GREEN_CONTAINER="fitrun-green"
 NGINX_CONTAINER="nginx"
 PROMTAIL_CONTAINER="promtail"
+NODE_EXPORTER_CONTAINER="node-exporter"
 
 MAX_RETRIES=60
 MAX_SCALE=1
@@ -46,6 +47,7 @@ switch_container() {
     run_nginx "${target}"
     stop_and_remove_container "${old}"
     run_promtail
+    run_node_exporter
     prune_images
 }
 
@@ -96,6 +98,11 @@ run_promtail() {
         cp "${SRC_PROMTAIL_PATH}" "${DST_PROMTAIL_PATH}"
         ${DOCKER_COMPOSE} restart "${PROMTAIL_CONTAINER}"
     fi
+}
+
+run_node_exporter() {
+    log_info "Starting ${NODE_EXPORTER_CONTAINER^^} container"
+    ensure_run_container "${NODE_EXPORTER_CONTAINER}"
 }
 
 run_service() {

--- a/deployment/staging/docker-compose.yml
+++ b/deployment/staging/docker-compose.yml
@@ -64,3 +64,20 @@ services:
     restart: unless-stopped
     networks:
       - app-tier
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    network_mode: host
+    pid: host
+    restart: unless-stopped
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+    ports:
+      - "9100:9100"


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 200

## 📄 추가 작업 내용
- 스테이징 환경에 Node Exporter를 구축합니다.


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항
https://www.notion.so/Node-Exporter-24d84e88f65b80729447c96303bd33c2?source=copy_link



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 스테이징 환경에 시스템 메트릭 수집이 추가되었습니다. Node Exporter를 통해 Prometheus 호환 메트릭이 포트 9100에서 제공되며, 배포 시 자동으로 실행되어 인프라 상태 관찰이 용이해졌습니다.
- 작업
  - 배포 구성과 스크립트를 업데이트하여 메트릭 수집 서비스를 배포 플로우에 통합했습니다. 기존 서비스에는 영향 없이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->