### PR TITLE
refactor: 러닝 포인트 저장 배치 처리(FITRUN-207)

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/record/domain/point/RunningPointDao.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/point/RunningPointDao.kt
@@ -8,9 +8,20 @@ import org.springframework.stereotype.Component
 @Component
 class RunningPointDao(
     private val runningPointRepository: RunningPointRepository,
+    private val runningPointJdbcBatchRepository: RunningPointJdbcBatchRepository,
 ) {
     fun save(runningPoint: RunningPoint): RunningPoint {
         return runningPointRepository.save(runningPoint)
+    }
+
+    fun saveAll(
+        runningRecord: RunningRecord,
+        runningPoints: List<RunningPoint>,
+    ) {
+        return runningPointJdbcBatchRepository.batchInsert(
+            recordId = runningRecord.id,
+            points = runningPoints,
+        )
     }
 
     fun get(id: Long): RunningPoint {

--- a/src/main/kotlin/com/yapp/yapp/record/domain/point/RunningPointJdbcBatchRepository.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/point/RunningPointJdbcBatchRepository.kt
@@ -1,0 +1,48 @@
+package com.yapp.yapp.record.domain.point
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class RunningPointJdbcBatchRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    fun batchInsert(
+        recordId: Long,
+        points: List<RunningPoint>,
+        batchSize: Int = 1000,
+    ) {
+        val sql =
+            """
+            INSERT INTO running_point (
+                running_record_id,
+                order_no,
+                lat,
+                lon,
+                distance,
+                pace,
+                calories,
+                total_running_time,
+                total_running_distance,
+                time_stamp,
+                is_deleted
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent()
+
+        points.chunked(batchSize).forEach { chunk ->
+            jdbcTemplate.batchUpdate(sql, chunk, chunk.size) { ps, p ->
+                ps.setLong(1, recordId)
+                ps.setLong(2, p.orderNo)
+                ps.setDouble(3, p.lat)
+                ps.setDouble(4, p.lon)
+                ps.setDouble(5, p.distance)
+                ps.setLong(6, p.pace.millsPerKm)
+                ps.setInt(7, p.calories)
+                ps.setLong(8, p.totalRunningTime)
+                ps.setDouble(9, p.totalRunningDistance)
+                ps.setTimestamp(10, java.sql.Timestamp(p.timeStamp.toInstant().toEpochMilli()))
+                ps.setBoolean(11, p.isDeleted)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/yapp/record/domain/point/RunningPointManger.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/point/RunningPointManger.kt
@@ -35,7 +35,7 @@ class RunningPointManger(
     ): RunningPoint {
         val preRunningPoint = getRecentRunningPoint(runningRecord)
         val newRunningPoint =
-            createNewRunningPoint(
+            createRunningPoint(
                 preRunningPoint = preRunningPoint,
                 runningRecord = runningRecord,
                 lat = lat,
@@ -53,7 +53,7 @@ class RunningPointManger(
         runningPointDao.saveAll(runningRecord = runningRecord, runningPoints = runningPoints)
     }
 
-    fun createNewRunningPoint(
+    fun createRunningPoint(
         preRunningPoint: RunningPoint,
         runningRecord: RunningRecord,
         lat: Double,

--- a/src/main/kotlin/com/yapp/yapp/record/domain/point/RunningPointManger.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/point/RunningPointManger.kt
@@ -33,7 +33,34 @@ class RunningPointManger(
         timeStamp: OffsetDateTime,
         totalRunningTimeMills: Long,
     ): RunningPoint {
-        val preRunningPoint = runningPointDao.getPrePointByRunningRecord(runningRecord)
+        val preRunningPoint = getRecentRunningPoint(runningRecord)
+        val newRunningPoint =
+            createNewRunningPoint(
+                preRunningPoint = preRunningPoint,
+                runningRecord = runningRecord,
+                lat = lat,
+                lon = lon,
+                timeStamp = timeStamp,
+                totalRunningTimeMills = totalRunningTimeMills,
+            )
+        return runningPointDao.save(newRunningPoint)
+    }
+
+    fun saveAllRunningPoints(
+        runningRecord: RunningRecord,
+        runningPoints: List<RunningPoint>,
+    ) {
+        runningPointDao.saveAll(runningRecord = runningRecord, runningPoints = runningPoints)
+    }
+
+    fun createNewRunningPoint(
+        preRunningPoint: RunningPoint,
+        runningRecord: RunningRecord,
+        lat: Double,
+        lon: Double,
+        timeStamp: OffsetDateTime,
+        totalRunningTimeMills: Long,
+    ): RunningPoint {
         val newRunningPoint =
             RunningPoint(
                 runningRecord = runningRecord,
@@ -46,10 +73,14 @@ class RunningPointManger(
         newRunningPoint.distance = RunningMetricsCalculator.calculateDistance(preRunningPoint, newRunningPoint)
         newRunningPoint.totalRunningDistance = preRunningPoint.totalRunningDistance + newRunningPoint.distance
         newRunningPoint.pace = Pace(distanceMeter = newRunningPoint.totalRunningDistance, durationMills = totalRunningTimeMills)
-        return runningPointDao.save(newRunningPoint)
+        return newRunningPoint
     }
 
     fun getRunningPoints(runningRecord: RunningRecord): List<RunningPoint> {
         return runningPointDao.getAllPointByRunningRecord(runningRecord)
+    }
+
+    fun getRecentRunningPoint(runningRecord: RunningRecord): RunningPoint {
+        return runningPointDao.getPrePointByRunningRecord(runningRecord)
     }
 }

--- a/src/main/kotlin/com/yapp/yapp/running/api/RunningController.kt
+++ b/src/main/kotlin/com/yapp/yapp/running/api/RunningController.kt
@@ -42,7 +42,7 @@ class RunningController(
         @RequestBody request: RunningDoneRequest,
     ): ApiResponse<RunningRecordResponse> {
         val recordResponse =
-            runningService.done(
+            runningService.doneBatch(
                 userId = userId,
                 recordId = recordId,
                 request = request,

--- a/src/main/kotlin/com/yapp/yapp/running/domain/RunningService.kt
+++ b/src/main/kotlin/com/yapp/yapp/running/domain/RunningService.kt
@@ -97,7 +97,7 @@ class RunningService(
         val runningPoints =
             request.runningPoints.map {
                 preRunningPoint =
-                    runningPointManger.createNewRunningPoint(
+                    runningPointManger.createRunningPoint(
                         preRunningPoint = preRunningPoint,
                         runningRecord = runningRecord,
                         lat = it.lat,

--- a/src/main/kotlin/com/yapp/yapp/running/domain/RunningService.kt
+++ b/src/main/kotlin/com/yapp/yapp/running/domain/RunningService.kt
@@ -57,6 +57,7 @@ class RunningService(
         if (request.runningPoints.isEmpty()) {
             throw CustomException(ErrorCode.POINT_NOT_FOUND)
         }
+
         val runningPoints =
             request.runningPoints.map {
                 runningPointManger.saveNewRunningPoint(
@@ -67,6 +68,46 @@ class RunningService(
                     timeStamp = TimeProvider.parse(it.timeStamp),
                 )
             }
+
+        if (userGoalManager.hasUserGoal(user)) {
+            recordGoalArchiveManager.update(runningRecord, userGoal = userGoalManager.getUserGoal(user))
+        }
+        runningRecordManager.updateRecord(runningRecord)
+
+        return RunningRecordResponse(
+            runningRecord = runningRecord,
+            runningPoints = runningPoints,
+            runningRecordGoalAchieve = recordGoalArchiveManager.getByRecord(runningRecord),
+        )
+    }
+
+    @Transactional
+    fun doneBatch(
+        userId: Long,
+        recordId: Long,
+        request: RunningDoneRequest,
+    ): RunningRecordResponse {
+        val user = userManager.getActiveUser(userId)
+        val runningRecord = runningRecordManager.getRunningRecord(id = recordId, user = user)
+        if (request.runningPoints.isEmpty()) {
+            throw CustomException(ErrorCode.POINT_NOT_FOUND)
+        }
+
+        var preRunningPoint = runningPointManger.getRecentRunningPoint(runningRecord)
+        val runningPoints =
+            request.runningPoints.map {
+                preRunningPoint =
+                    runningPointManger.createNewRunningPoint(
+                        preRunningPoint = preRunningPoint,
+                        runningRecord = runningRecord,
+                        lat = it.lat,
+                        lon = it.lon,
+                        totalRunningTimeMills = it.totalRunningTimeMills,
+                        timeStamp = TimeProvider.parse(it.timeStamp),
+                    )
+                preRunningPoint
+            }
+        runningPointManger.saveAllRunningPoints(runningRecord, runningPoints)
 
         if (userGoalManager.hasUserGoal(user)) {
             recordGoalArchiveManager.update(runningRecord, userGoal = userGoalManager.getUserGoal(user))


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 207

## 📄 추가 작업 내용
-


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항
러닝 포인트 저장을 배치처리하여 성능을 30초에서 800ms로 개선했습니다.
우선 빠르게 핫픽스로 처리하고 추후 문서화와 개선 작업을 추가하겠습니다!

<img width="2028" height="1124" alt="image" src="https://github.com/user-attachments/assets/dd54ea26-fcd9-4eeb-b6f7-7d70f436fc0c" />
<img width="2048" height="1188" alt="image" src="https://github.com/user-attachments/assets/1db88145-7522-44bb-a002-8620c74739c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 러닝 종료 시 수집된 위치 포인트를 일괄 저장하여 한 번에 처리하도록 추가했습니다.
  * 대량의 러닝 포인트 업로드를 안정적으로 지원합니다.
* **개선**
  * 거리·페이스·누적 시간/거리 계산 로직을 분리해 결과 일관성과 유지보수성을 높였습니다.
  * 기존 종료 API 호출 방식은 변경 없이 동일하게 이용할 수 있으며, 전체 처리 성능과 응답 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->