### PR TITLE
refactor: 목표 미설정 null 처리

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/home/domain/HomeService.kt
+++ b/src/main/kotlin/com/yapp/yapp/home/domain/HomeService.kt
@@ -5,14 +5,12 @@ import com.yapp.yapp.record.domain.RecordsSearchType
 import com.yapp.yapp.record.domain.record.RunningRecordManager
 import com.yapp.yapp.user.domain.UserManager
 import com.yapp.yapp.user.domain.goal.UserGoalManager
-import com.yapp.yapp.user.domain.onboarding.OnboardingManager
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime
 
 @Service
 class HomeService(
     private val userManager: UserManager,
-    private val onboardingManager: OnboardingManager,
     private val recordManager: RunningRecordManager,
     private val userGoalManager: UserGoalManager,
 ) {

--- a/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordListResponse.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/api/response/RunningRecordListResponse.kt
@@ -1,5 +1,7 @@
 package com.yapp.yapp.record.api.response
 
+import com.yapp.yapp.user.domain.goal.UserGoal
+
 data class RunningRecordListResponse(
     val userId: Long,
     val records: List<RunningRecordSummaryResponse>,
@@ -7,19 +9,19 @@ data class RunningRecordListResponse(
     val totalDistance: Double,
     val totalTime: Long,
     val totalCalories: Int,
-    val averagePace: Long,
-    val timeGoalAchievedCount: Int,
-    val distanceGoalAchievedCount: Int,
+    val averagePace: Long?,
+    val timeGoalAchievedCount: Int?,
+    val distanceGoalAchievedCount: Int?,
 ) {
-    constructor(userId: Long, records: List<RunningRecordResponse>) : this(
+    constructor(userId: Long, records: List<RunningRecordResponse>, userGoal: UserGoal) : this(
         userId = userId,
         records = records.map { RunningRecordSummaryResponse(it) },
         recordCount = records.size,
         totalDistance = records.sumOf { it.totalDistance },
         totalTime = records.fold(0L) { acc, record -> acc.plus(record.totalTime) },
         totalCalories = records.sumOf { it.totalCalories },
-        averagePace = records.map { it.averagePace }.average().toLong(),
-        timeGoalAchievedCount = records.count { it.isTimeGoalAchieved },
-        distanceGoalAchievedCount = records.count { it.isDistanceGoalAchieved },
+        averagePace = if (records.isEmpty()) null else records.map { it.averagePace }.average().toLong(),
+        timeGoalAchievedCount = if (userGoal.hasTimeGoal()) records.count { it.isTimeGoalAchieved } else null,
+        distanceGoalAchievedCount = if (userGoal.hasDistanceGoal()) records.count { it.isDistanceGoalAchieved } else null,
     )
 }

--- a/src/main/kotlin/com/yapp/yapp/record/domain/RunningRecordService.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/RunningRecordService.kt
@@ -6,6 +6,7 @@ import com.yapp.yapp.record.domain.point.RunningPointManger
 import com.yapp.yapp.record.domain.record.RunningRecordManager
 import com.yapp.yapp.record.domain.record.goal.RunningRecordGoalAchieveManager
 import com.yapp.yapp.user.domain.UserManager
+import com.yapp.yapp.user.domain.goal.UserGoalManager
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,6 +17,7 @@ class RunningRecordService(
     private val recordManager: RunningRecordManager,
     private val pointManager: RunningPointManger,
     private val userManager: UserManager,
+    private val userGoalManager: UserGoalManager,
     private val recordGoalAchieveManager: RunningRecordGoalAchieveManager,
 ) {
     fun getRecord(
@@ -55,6 +57,7 @@ class RunningRecordService(
         return RunningRecordListResponse(
             userId = user.id,
             records = runningRecordResponse,
+            userGoal = userGoalManager.getUserGoal(user),
         )
     }
 

--- a/src/main/kotlin/com/yapp/yapp/record/domain/converter/PaceConverter.kt
+++ b/src/main/kotlin/com/yapp/yapp/record/domain/converter/PaceConverter.kt
@@ -11,6 +11,9 @@ class PaceConverter : AttributeConverter<Pace, Long> {
     }
 
     override fun convertToEntityAttribute(dbData: Long?): Pace? {
-        return Pace(dbData ?: 0L)
+        if (dbData == null) {
+            return null
+        }
+        return Pace(dbData)
     }
 }

--- a/src/main/kotlin/com/yapp/yapp/user/domain/goal/UserGoal.kt
+++ b/src/main/kotlin/com/yapp/yapp/user/domain/goal/UserGoal.kt
@@ -65,4 +65,12 @@ class UserGoal(
         if (this.paceGoal == null) return false
         return runningRecord.averagePace.toMills() <= this.paceGoal?.millsPerKm as Long
     }
+
+    fun hasTimeGoal(): Boolean {
+        return this.timeGoal != null
+    }
+
+    fun hasDistanceGoal(): Boolean {
+        return this.distanceMeterGoal != null
+    }
 }

--- a/src/test/kotlin/com/yapp/yapp/home/HomeControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/home/HomeControllerTest.kt
@@ -1,8 +1,6 @@
 package com.yapp.yapp.home
 
 import com.yapp.yapp.support.BaseControllerTest
-import com.yapp.yapp.user.api.request.RunningPurposeRequest
-import com.yapp.yapp.user.domain.goal.RunningPurposeAnswerLabel
 import io.restassured.RestAssured
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
@@ -13,22 +11,12 @@ class HomeControllerTest : BaseControllerTest() {
     fun `러닝 목표가 없는 유저의 홈 화면에서 목표는 null이다 `() {
         // given
         val email = "test@test.com"
-        val user = userFixture.create(email)
-        val accessToken = getAccessToken(user.email)
-
-        val request = RunningPurposeRequest(RunningPurposeAnswerLabel.COMPETITION_PREPARATION)
-        RestAssured.given().log().all()
-            .header(HttpHeaders.AUTHORIZATION, accessToken)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(request)
-            .`when`().post("/api/v1/users/goals/purpose")
-            .then().log().all()
-            .statusCode(201)
+        val user = userFixture.createWithPurposeGoal(email)
 
         // when
         // then
         RestAssured.given().log().all()
-            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .header(HttpHeaders.AUTHORIZATION, getAccessToken(user.email))
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .`when`().get("/api/v1/home")
             .then().log().all()

--- a/src/test/kotlin/com/yapp/yapp/home/HomeControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/home/HomeControllerTest.kt
@@ -10,7 +10,7 @@ import org.springframework.http.MediaType
 
 class HomeControllerTest : BaseControllerTest() {
     @Test
-    fun `러닝 목표가 없는 유저의 목표는 null이다 `() {
+    fun `러닝 목표가 없는 유저의 홈 화면에서 목표는 null이다 `() {
         // given
         val email = "test@test.com"
         val user = userFixture.create(email)

--- a/src/test/kotlin/com/yapp/yapp/home/HomeControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/home/HomeControllerTest.kt
@@ -1,0 +1,37 @@
+package com.yapp.yapp.home
+
+import com.yapp.yapp.support.BaseControllerTest
+import com.yapp.yapp.user.api.request.RunningPurposeRequest
+import com.yapp.yapp.user.domain.goal.RunningPurposeAnswerLabel
+import io.restassured.RestAssured
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+
+class HomeControllerTest : BaseControllerTest() {
+    @Test
+    fun `러닝 목표가 없는 유저의 목표는 null이다 `() {
+        // given
+        val email = "test@test.com"
+        val user = userFixture.create(email)
+        val accessToken = getAccessToken(user.email)
+
+        val request = RunningPurposeRequest(RunningPurposeAnswerLabel.COMPETITION_PREPARATION)
+        RestAssured.given().log().all()
+            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(request)
+            .`when`().post("/api/v1/users/goals/purpose")
+            .then().log().all()
+            .statusCode(201)
+
+        // when
+        // then
+        RestAssured.given().log().all()
+            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .`when`().get("/api/v1/home")
+            .then().log().all()
+            .statusCode(200)
+    }
+}

--- a/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/record/RunningRecordControllerTest.kt
@@ -7,7 +7,6 @@ import com.yapp.yapp.record.api.response.RunningRecordListResponse
 import com.yapp.yapp.record.domain.RecordsSearchType
 import com.yapp.yapp.running.domain.RunningService
 import com.yapp.yapp.support.BaseControllerTest
-import com.yapp.yapp.support.fixture.RequestFixture
 import io.restassured.RestAssured
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
@@ -145,14 +144,7 @@ class RunningRecordControllerTest : BaseControllerTest() {
     @Test
     fun `목표가 없는 사용자가 러닝 기록 리스트를 조회한다`() {
         // given
-        val user = userFixture.create()
-        val startResponse = runningService.start(userId = user.id, request = RequestFixture.runningStartRequest())
-        val recordId = startResponse.recordId
-        runningService.done(
-            userId = user.id,
-            recordId = recordId,
-            request = RequestFixture.runningDoneRequest(),
-        )
+        val user = userFixture.createWithPurposeGoal()
 
         // when
         // then

--- a/src/test/kotlin/com/yapp/yapp/support/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/yapp/yapp/support/fixture/UserFixture.kt
@@ -48,6 +48,24 @@ class UserFixture(
         return user
     }
 
+    fun createWithPurposeGoal(
+        email: String = "test email",
+        provider: ProviderType = ProviderType.APPLE,
+        runnerType: RunnerType = RunnerType.BEGINNER,
+    ): User {
+        val user =
+            userRepository.save(
+                User(
+                    nickname = NicknameGenerator.generate(email),
+                    email = email,
+                    provider = provider,
+                    runnerType = runnerType,
+                ),
+            )
+        userGoalFixture.create(user = user, distanceMeterGoal = null, timeGoal = null, weeklyRunCount = null, paceGoal = null)
+        return user
+    }
+
     fun createWithdrawUser(
         user: User,
         reason: String? = null,

--- a/src/test/kotlin/com/yapp/yapp/support/fixture/UserGoalFixture.kt
+++ b/src/test/kotlin/com/yapp/yapp/support/fixture/UserGoalFixture.kt
@@ -14,10 +14,10 @@ class UserGoalFixture(
 ) {
     fun create(
         user: User,
-        distanceMeterGoal: Double = 5000.0,
-        timeGoal: Long = TimeProvider.toMills(minute = 40, second = 30),
-        weeklyRunCount: Int = 3,
-        paceGoal: Pace = Pace(distanceMeter = 5000.0, durationMills = TimeProvider.toMills(minute = 40, second = 30)),
+        distanceMeterGoal: Double? = 5000.0,
+        timeGoal: Long? = TimeProvider.toMills(minute = 40, second = 30),
+        weeklyRunCount: Int? = 3,
+        paceGoal: Pace? = Pace(distanceMeter = 5000.0, durationMills = TimeProvider.toMills(minute = 40, second = 30)),
         runningPurpose: RunningPurposeAnswerLabel = RunningPurposeAnswerLabel.WEIGHT_LOSS_PURPOSE,
     ): UserGoal {
         return userGoalRepository.save(


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 

## 📄 추가 작업 내용
-


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 러닝 기록 목록에 목표 달성 통계가 추가되었습니다: 시간/거리 목표가 설정된 경우 각각의 달성 횟수를 제공합니다. 목표가 없으면 해당 항목은 표시되지 않습니다.

- 개선/변경
  - 평균 페이스는 기록이 없을 때 표시되지 않습니다(값 없음). 기존 기록이 있는 경우에만 값이 제공됩니다.
  - 홈 화면에서 목표가 없는 유저는 목표가 null로 표시됩니다.

- 버그 수정
  - 페이스 데이터가 없을 때 0으로 잘못 표시되던 문제를 수정하여 값이 비어있도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->