### PR TITLE
feat: 오디오 레이스 시작 beep 추가

### DIFF
--- a/src/main/kotlin/com/yapp/yapp/audio/api/AudioController.kt
+++ b/src/main/kotlin/com/yapp/yapp/audio/api/AudioController.kt
@@ -36,6 +36,13 @@ class AudioController(
     }
 
     @Authenticated
+    @GetMapping("/running-start-beeps")
+    fun getStartBeepsAudio(): ResponseEntity<Resource> {
+        val audioResource = audioService.getRunningStartBeeps()
+        return AudioServletHandler.handleAudioResource(audioResource)
+    }
+
+    @Authenticated
     @GetMapping("/running-info")
     fun getRunningInfoAudio(
         @RequestParam paceMills: Long,

--- a/src/main/kotlin/com/yapp/yapp/audio/domain/AudioDao.kt
+++ b/src/main/kotlin/com/yapp/yapp/audio/domain/AudioDao.kt
@@ -25,4 +25,8 @@ class AudioDao(
     fun getPaceGoalAudio(type: PaceAudioType): AudioResource {
         return audioRepository.getPaceGoalAudio(type)
     }
+
+    fun getRunningStartBeeps(): AudioResource {
+        return audioRepository.getRunningStartBeeps()
+    }
 }

--- a/src/main/kotlin/com/yapp/yapp/audio/domain/AudioManager.kt
+++ b/src/main/kotlin/com/yapp/yapp/audio/domain/AudioManager.kt
@@ -31,4 +31,8 @@ class AudioManager(
         val pace = Pace(paceMills)
         return "현재 페이스는 ${pace.toAudioText()}입니다."
     }
+
+    fun getRunningStartBeeps(): AudioResource {
+        return audioDao.getRunningStartBeeps()
+    }
 }

--- a/src/main/kotlin/com/yapp/yapp/audio/domain/AudioRepository.kt
+++ b/src/main/kotlin/com/yapp/yapp/audio/domain/AudioRepository.kt
@@ -10,4 +10,6 @@ interface AudioRepository {
     fun getTimeGoalAudio(type: TimeAudioType): AudioResource
 
     fun getPaceGoalAudio(type: PaceAudioType): AudioResource
+
+    fun getRunningStartBeeps(): AudioResource
 }

--- a/src/main/kotlin/com/yapp/yapp/audio/domain/AudioService.kt
+++ b/src/main/kotlin/com/yapp/yapp/audio/domain/AudioService.kt
@@ -31,4 +31,8 @@ class AudioService(
         val audioText = audioManager.getPaceAudioText(paceMills)
         return ttsManager.synthesize(audioText)
     }
+
+    fun getRunningStartBeeps(): AudioResource {
+        return audioManager.getRunningStartBeeps()
+    }
 }

--- a/src/main/kotlin/com/yapp/yapp/audio/domain/infrastructure/GoogleAudioRepository.kt
+++ b/src/main/kotlin/com/yapp/yapp/audio/domain/infrastructure/GoogleAudioRepository.kt
@@ -21,6 +21,7 @@ class GoogleAudioRepository(
     @Value("\${gcp.bucket}") private val bucketName: String,
 ) : AudioRepository {
     companion object {
+        private val START_BEEPS = "running/start-beeps.wav"
         private val COACH_AUDIO_PATHS =
             listOf(
                 "coach/coach-01.wav",
@@ -140,6 +141,10 @@ class GoogleAudioRepository(
             PACE_AUDIO_PATH_MAP[type]?.random()
                 ?: throw CustomException(ErrorCode.INVALID_PACE_AUDIO_TYPE)
         return getAudioResource(filePath)
+    }
+
+    override fun getRunningStartBeeps(): AudioResource {
+        return getAudioResource(START_BEEPS)
     }
 
     private fun getAudioResource(filePath: String): AudioResource {

--- a/src/test/kotlin/com/yapp/yapp/document/audio/AudioDocumentTest.kt
+++ b/src/test/kotlin/com/yapp/yapp/document/audio/AudioDocumentTest.kt
@@ -13,6 +13,35 @@ import org.springframework.restdocs.request.RequestDocumentation.parameterWithNa
 
 class AudioDocumentTest : BaseDocumentTest() {
     @Test
+    fun `오디오 러닝 시작 API`() {
+        // given
+        val restDocsRequest =
+            request()
+                .requestHeader(
+                    headerWithName("Authorization").description("엑세스 토큰(Bearer)"),
+                )
+
+        val filter =
+            filter("audio", "start-beeps")
+                .tag(Tag.AUDIO_API)
+                .summary("오디오 러닝 시작 API")
+                .description(
+                    "러닝 시작 효과음 API입니다.<br>" +
+                        "Content-Type: audio/wav;charset=UTF-8 입니다.",
+                )
+                .request(restDocsRequest)
+                .build()
+
+        // when & then
+        RestAssured.given(spec).log().all()
+            .header(HttpHeaders.AUTHORIZATION, getAccessToken())
+            .filter(filter)
+            .`when`().get("/api/v1/audios/running-start-beeps")
+            .then().log().all()
+            .statusCode(200)
+    }
+
+    @Test
     fun `오디오 코치용 API`() {
         // given
         val restDocsRequest =


### PR DESCRIPTION
## 📎 관련 이슈
- Jira: FITRUN 

## 📄 추가 작업 내용
-


## ✅ Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## 💬 기타 참고 사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 러닝 시작을 알리는 비프음 오디오 리소스 제공 API 추가(인증 필요). 클라이언트는 러닝 시작 시 즉시 재생 가능한 오디오를 안정적으로 받을 수 있습니다. 기존 오디오 기능에는 영향이 없습니다.
* 문서
  * 새 오디오 엔드포인트 및 인증 헤더 요구사항을 API 문서에 추가했습니다.
* 테스트
  * 새 엔드포인트의 정상 응답과 문서 생성을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->